### PR TITLE
Add GetJsonSerializerOptions

### DIFF
--- a/src/DynamicJsonPropertyNamingPolicy.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/src/DynamicJsonPropertyNamingPolicy.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -9,19 +9,19 @@ namespace DynamicJsonPropertyNamingPolicy.Tests.Extensions
 {
     public class HttpContextExtensionsTests
     {
-        public static IEnumerable<object[]> NamingPolicyData
+        public static IEnumerable<object[]> NamingOptionData
             => new[]
             {
-                new object[] {"snake", JsonNamingPolicyOptions.SnakeCase},
-                new object[] {"camel", JsonNamingPolicyOptions.CamelCase},
-                new object[] {"pascal", JsonNamingPolicyOptions.PascalCase},
-                new object[] {"unclegeorge", JsonNamingPolicyOptions.SnakeCase},
-                new object[] {null, JsonNamingPolicyOptions.SnakeCase}
+                new object[] {"snake", HttpContextExtensions._snakeCaseOptions},
+                new object[] {"camel", HttpContextExtensions._camelCaseOptions},
+                new object[] {"pascal", HttpContextExtensions._pascalCaseOptions},
+                new object[] {"unclegeorge", HttpContextExtensions._snakeCaseOptions},
+                new object[] {null, HttpContextExtensions._snakeCaseOptions}
             };
 
         [Theory]
-        [MemberData(nameof(NamingPolicyData))]
-        public void GetJsonNamingPolicyTest(string headerValue, JsonNamingPolicy expected)
+        [MemberData(nameof(NamingOptionData))]
+        public void GetJsonNamingPolicyTest(string headerValue, JsonSerializerOptions expected)
         {
             // Arrange
             HttpContext context = new DefaultHttpContext();
@@ -34,7 +34,25 @@ namespace DynamicJsonPropertyNamingPolicy.Tests.Extensions
             JsonNamingPolicy actual = context.GetJsonNamingPolicy();
 
             // Assert
-            Assert.Equal(expected, actual);
+            Assert.Equal(expected.PropertyNamingPolicy, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(NamingOptionData))]
+        public void GetJsonSerializerOptionsTest(string headerValue, JsonSerializerOptions expected)
+        {
+            // Arrange
+            HttpContext context = new DefaultHttpContext();
+            if (headerValue != null)
+            {
+                context.Request.Headers.Add("json-naming-strategy", headerValue);
+            }
+
+            // Act
+            JsonSerializerOptions actual = context.GetJsonSerializerOptions();
+
+            // Assert
+            Assert.Same(expected, actual);
         }
     }
 }

--- a/src/DynamicJsonPropertyNamingPolicy/Extensions/HttpContextExtensions.cs
+++ b/src/DynamicJsonPropertyNamingPolicy/Extensions/HttpContextExtensions.cs
@@ -10,6 +10,34 @@ namespace DynamicJsonPropertyNamingPolicy.Extensions
     /// </summary>
     public static class HttpContextExtensions
     {
+        internal static readonly string _headerName = "json-naming-strategy";
+
+        // Based on: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-configure-options
+        // it is best to reuse instances of the JsonSerializerOptions.
+        internal static readonly JsonSerializerOptions _snakeCaseOptions =
+            new() { PropertyNamingPolicy = JsonNamingPolicyOptions.SnakeCase };
+        internal static readonly JsonSerializerOptions _camelCaseOptions =
+            new() { PropertyNamingPolicy = JsonNamingPolicyOptions.CamelCase };
+        internal static readonly JsonSerializerOptions _pascalCaseOptions =
+            new() { PropertyNamingPolicy = JsonNamingPolicyOptions.PascalCase };
+
+        /// <summary>
+        /// Get the <cref>System.Text.Json.JsonSerializerOptions</cref> based on the request headers of the <paramref name="context" />.
+        /// </summary>
+        /// <param name="context">The <cref>Microsoft.AspNetCore.Http.HttpContext</cref> to inspect.</param>
+        /// <returns>The <cref>System.Text.Json.JsonSerializerOptions</cref> that should be used based on the headers.</returns>
+        public static JsonSerializerOptions GetJsonSerializerOptions(this HttpContext context)
+        {
+            // Default to snake for backwards compatibility
+            context.Request.Headers.TryGetValue(_headerName, out StringValues name);
+            return name.ToString() switch
+            {
+                "pascal" => _pascalCaseOptions,
+                "camel" => _camelCaseOptions,
+                _ => _snakeCaseOptions
+            };
+        }
+
         /// <summary>
         /// Get the <cref>System.Text.Json.JsonNamingPolicy</cref> based on the request headers of the <paramref name="context" />.
         /// </summary>
@@ -17,14 +45,7 @@ namespace DynamicJsonPropertyNamingPolicy.Extensions
         /// <returns>The <cref>System.Text.Json.JsonNamingPolicy</cref> that should be used based on the headers.</returns>
         public static JsonNamingPolicy? GetJsonNamingPolicy(this HttpContext context)
         {
-            // Default to snake for backwards compatibility
-            context.Request.Headers.TryGetValue("json-naming-strategy", out StringValues name);
-            return name.ToString() switch
-            {
-                "pascal" => JsonNamingPolicyOptions.PascalCase,
-                "camel" => JsonNamingPolicyOptions.CamelCase,
-                _ => JsonNamingPolicyOptions.SnakeCase
-            };
+            return context.GetJsonSerializerOptions().PropertyNamingPolicy;
         }
     }
 }


### PR DESCRIPTION
Based on https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-configure-options it's better to reuse JsonSerializerOptions when possible.