### PR TITLE
Handle null context and cancelled requests better

### DIFF
--- a/src/DynamicJsonPropertyNamingPolicy.Tests/JsonNamingPolicies/DynamicSystemTextJsonInputFormatterUnitTests.cs
+++ b/src/DynamicJsonPropertyNamingPolicy.Tests/JsonNamingPolicies/DynamicSystemTextJsonInputFormatterUnitTests.cs
@@ -1,5 +1,8 @@
+using System;
 using System.IO;
 using System.Text;
+using System.Threading;
+using DynamicJsonPropertyNamingPolicy.JsonNamingPolicies;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -7,10 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using DynamicJsonPropertyNamingPolicy.JsonNamingPolicies;
 using Xunit;
-using System;
-using System.Threading;
 
 namespace DynamicJsonPropertyNamingPolicy.Tests.JsonNamingPolicies
 {

--- a/src/DynamicJsonPropertyNamingPolicy.Tests/JsonNamingPolicies/DynamicSystemTextJsonInputFormatterUnitTests.cs
+++ b/src/DynamicJsonPropertyNamingPolicy.Tests/JsonNamingPolicies/DynamicSystemTextJsonInputFormatterUnitTests.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using DynamicJsonPropertyNamingPolicy.JsonNamingPolicies;
 using Xunit;
+using System;
+using System.Threading;
 
 namespace DynamicJsonPropertyNamingPolicy.Tests.JsonNamingPolicies
 {
@@ -57,6 +59,69 @@ namespace DynamicJsonPropertyNamingPolicy.Tests.JsonNamingPolicies
             Assert.NotNull(actual.Model);
             Assert.IsType<SampleType>(actual.Model);
             Assert.Equal(policyName, ((SampleType)actual.Model).NamingPolicy);
+        }
+
+        [Fact]
+        public async void NullContextThrowsException()
+        {
+            // Arrange
+            Encoding encoding = Encoding.UTF8;
+            DynamicSystemTextJsonInputFormatter formatter = new();
+
+            // Act
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await formatter.ReadRequestBodyAsync(null, encoding));
+
+            // Assert
+        }
+
+        [Fact]
+        public async void NullEncodingThrowsException()
+        {
+            // Arrange
+            InputFormatterContext context = new(
+                new DefaultHttpContext(),
+                nameof(SampleType),
+                new ModelStateDictionary(),
+                new EmptyModelMetadataProvider().GetMetadataForType(typeof(SampleType)),
+                (stream, encoding) => new StreamReader(stream, encoding));
+            DynamicSystemTextJsonInputFormatter formatter = new();
+
+            // Act
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await formatter.ReadRequestBodyAsync(context, null));
+
+            // Assert
+        }
+
+        [Fact]
+        public async void RequestAbortedReturnsNoValue()
+        {
+            // Arrange
+            InputFormatterResult expected = InputFormatterResult.NoValue();
+            Encoding encoding = Encoding.UTF8;
+            IServiceCollection serviceCollection = new ServiceCollection();
+            serviceCollection.TryAddSingleton<ILogger<SystemTextJsonInputFormatter>>(
+                new NullLogger<SystemTextJsonInputFormatter>());
+            ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true
+            });
+            DefaultHttpContext httpContext = new();
+            httpContext.RequestServices = serviceProvider;
+            InputFormatterContext context = new(
+                httpContext,
+                nameof(SampleType),
+                new ModelStateDictionary(),
+                new EmptyModelMetadataProvider().GetMetadataForType(typeof(SampleType)),
+                (stream, encoding) => new StreamReader(stream, encoding));
+            DynamicSystemTextJsonInputFormatter formatter = new();
+            httpContext.RequestAborted = new CancellationToken(true);
+
+            // Act
+            InputFormatterResult actual = await formatter.ReadRequestBodyAsync(context, encoding);
+
+            // Assert
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/DynamicJsonPropertyNamingPolicy.Tests/JsonNamingPolicies/DynamicSystemTextJsonInputFormatterUnitTests.cs
+++ b/src/DynamicJsonPropertyNamingPolicy.Tests/JsonNamingPolicies/DynamicSystemTextJsonInputFormatterUnitTests.cs
@@ -69,9 +69,8 @@ namespace DynamicJsonPropertyNamingPolicy.Tests.JsonNamingPolicies
             DynamicSystemTextJsonInputFormatter formatter = new();
 
             // Act
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await formatter.ReadRequestBodyAsync(null, encoding));
-
             // Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await formatter.ReadRequestBodyAsync(null, encoding));
         }
 
         [Fact]

--- a/src/DynamicJsonPropertyNamingPolicy.Tests/JsonNamingPolicies/DynamicSystemTextJsonInputFormatterUnitTests.cs
+++ b/src/DynamicJsonPropertyNamingPolicy.Tests/JsonNamingPolicies/DynamicSystemTextJsonInputFormatterUnitTests.cs
@@ -86,9 +86,8 @@ namespace DynamicJsonPropertyNamingPolicy.Tests.JsonNamingPolicies
             DynamicSystemTextJsonInputFormatter formatter = new();
 
             // Act
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await formatter.ReadRequestBodyAsync(context, null));
-
             // Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await formatter.ReadRequestBodyAsync(context, null));
         }
 
         [Fact]

--- a/src/DynamicJsonPropertyNamingPolicy/JsonNamingPolicies/DynamicSystemTextJsonInputFormatter.cs
+++ b/src/DynamicJsonPropertyNamingPolicy/JsonNamingPolicies/DynamicSystemTextJsonInputFormatter.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using DynamicJsonPropertyNamingPolicy.Extensions;
+using System;
+using Microsoft.AspNetCore.Http;
 
 namespace DynamicJsonPropertyNamingPolicy.JsonNamingPolicies
 {
@@ -25,9 +27,26 @@ namespace DynamicJsonPropertyNamingPolicy.JsonNamingPolicies
         /// <inheritdoc />
         public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding)
         {
-            ILogger<SystemTextJsonInputFormatter> inputLogger = context.HttpContext.RequestServices.GetRequiredService<ILogger<SystemTextJsonInputFormatter>>();
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            HttpContext httpContext = context.HttpContext;
+
+            if (httpContext.RequestAborted.IsCancellationRequested)
+            {
+                return InputFormatterResult.NoValue();
+            }
+
+            ILogger<SystemTextJsonInputFormatter> inputLogger = httpContext.RequestServices.GetRequiredService<ILogger<SystemTextJsonInputFormatter>>();
             JsonOptions options = new();
-            options.JsonSerializerOptions.PropertyNamingPolicy = context.HttpContext.GetJsonNamingPolicy();
+            options.JsonSerializerOptions.PropertyNamingPolicy = httpContext.GetJsonNamingPolicy();
 
             TextInputFormatter formatter = new SystemTextJsonInputFormatter(options, inputLogger);
             InputFormatterResult result = await formatter.ReadRequestBodyAsync(context, encoding);

--- a/src/DynamicJsonPropertyNamingPolicy/JsonNamingPolicies/DynamicSystemTextJsonInputFormatter.cs
+++ b/src/DynamicJsonPropertyNamingPolicy/JsonNamingPolicies/DynamicSystemTextJsonInputFormatter.cs
@@ -1,12 +1,12 @@
+using System;
 using System.Text;
 using System.Threading.Tasks;
+using DynamicJsonPropertyNamingPolicy.Extensions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using DynamicJsonPropertyNamingPolicy.Extensions;
-using System;
-using Microsoft.AspNetCore.Http;
 
 namespace DynamicJsonPropertyNamingPolicy.JsonNamingPolicies
 {


### PR DESCRIPTION
Better handle when a request is cancelled and more explicit handling of null input for the `ReadRequestBodyAsync` method.